### PR TITLE
v12 fixes

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -24,7 +24,7 @@ use super::error::DecodingError;
 use core::cmp;
 use core::fmt;
 use core::hash;
-use ed25519_dalek::{self as ed25519, Signer as _, Verifier as _};
+use ed25519_dalek::{self as ed25519, Signer as _};
 use std::convert::TryFrom;
 use zeroize::Zeroize;
 
@@ -141,9 +141,17 @@ impl cmp::Ord for PublicKey {
 
 impl PublicKey {
     /// Verify the Ed25519 signature on a message using the public key.
+    ///
+    /// This function uses strict verification which:
+    /// - Rejects weak (small-order) public keys
+    /// - Rejects signatures with malleable components (torsion in R)
+    /// - Ensures the signature scalar is properly reduced
+    ///
+    /// These checks are important for protocols that rely on signature verification
+    /// as proof of key possession.
     pub fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
         ed25519::Signature::try_from(sig)
-            .and_then(|s| self.0.verify(msg, &s))
+            .and_then(|s| self.0.verify_strict(msg, &s))
             .is_ok()
     }
 
@@ -154,12 +162,26 @@ impl PublicKey {
     }
 
     /// Try to parse a public key from a byte array containing the actual key as produced by `to_bytes`.
+    ///
+    /// This function rejects weak (small-order) public keys to prevent signature forgery attacks.
+    /// Small-order public keys can be used to create signatures that verify without knowledge
+    /// of the corresponding private key, breaking proof-of-possession guarantees.
     pub fn try_from_bytes(k: &[u8]) -> Result<PublicKey, DecodingError> {
         let k = <[u8; 32]>::try_from(k)
             .map_err(|e| DecodingError::failed_to_parse("Ed25519 public key", e))?;
-        ed25519::VerifyingKey::from_bytes(&k)
-            .map_err(|e| DecodingError::failed_to_parse("Ed25519 public key", e))
-            .map(PublicKey)
+        let vk = ed25519::VerifyingKey::from_bytes(&k)
+            .map_err(|e| DecodingError::failed_to_parse("Ed25519 public key", e))?;
+
+        // Reject weak/small-order public keys to prevent signature forgery.
+        // Small-order points (like the identity point) can satisfy the verification
+        // equation for trivial signatures without requiring knowledge of a private key.
+        if vk.is_weak() {
+            return Err(DecodingError::new(
+                "Ed25519 weak public key rejected: small-order points are not allowed".to_string(),
+            ));
+        }
+
+        Ok(PublicKey(vk))
     }
 }
 
@@ -254,5 +276,93 @@ mod tests {
 
         let invalid_msg = "h3ll0 w0rld".as_bytes();
         assert!(!pk.verify(invalid_msg, &sig));
+    }
+
+    /// The 8 small-order points on the Ed25519 curve (the 8-torsion subgroup).
+    /// These are weak public keys that can be used to forge signatures.
+    /// Reference: https://cr.yp.to/ecdh/curve25519-20060209.pdf
+    const SMALL_ORDER_POINTS: [[u8; 32]; 8] = [
+        // Identity point (neutral element)
+        [
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ],
+        // Order 8 point
+        [
+            0xec, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0x7f,
+        ],
+        // Order 8 point  
+        [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x80,
+        ],
+        // Order 2 point
+        [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ],
+        // Order 4 point
+        [
+            0xc7, 0x17, 0x6a, 0x70, 0x3d, 0x4d, 0xd8, 0x4f, 0xba, 0x3c, 0x0b, 0x76, 0x0d, 0x10,
+            0x67, 0x0f, 0x2a, 0x20, 0x53, 0xfa, 0x2c, 0x39, 0xcc, 0xc6, 0x4e, 0xc7, 0xfd, 0x77,
+            0x92, 0xac, 0x03, 0x7a,
+        ],
+        // Order 4 point
+        [
+            0xc7, 0x17, 0x6a, 0x70, 0x3d, 0x4d, 0xd8, 0x4f, 0xba, 0x3c, 0x0b, 0x76, 0x0d, 0x10,
+            0x67, 0x0f, 0x2a, 0x20, 0x53, 0xfa, 0x2c, 0x39, 0xcc, 0xc6, 0x4e, 0xc7, 0xfd, 0x77,
+            0x92, 0xac, 0x03, 0xfa,
+        ],
+        // Order 8 point
+        [
+            0x26, 0xe8, 0x95, 0x8f, 0xc2, 0xb2, 0x27, 0xb0, 0x45, 0xc3, 0xf4, 0x89, 0xf2, 0xef,
+            0x98, 0xf0, 0xd5, 0xdf, 0xac, 0x05, 0xd3, 0xc6, 0x33, 0x39, 0xb1, 0x38, 0x02, 0x88,
+            0x6d, 0x53, 0xfc, 0x05,
+        ],
+        // Order 8 point
+        [
+            0x26, 0xe8, 0x95, 0x8f, 0xc2, 0xb2, 0x27, 0xb0, 0x45, 0xc3, 0xf4, 0x89, 0xf2, 0xef,
+            0x98, 0xf0, 0xd5, 0xdf, 0xac, 0x05, 0xd3, 0xc6, 0x33, 0x39, 0xb1, 0x38, 0x02, 0x88,
+            0x6d, 0x53, 0xfc, 0x85,
+        ],
+    ];
+
+    #[test]
+    fn reject_weak_public_keys_on_import() {
+        // Test that all small-order (weak) public keys are rejected during import
+        for (i, weak_key) in SMALL_ORDER_POINTS.iter().enumerate() {
+            let result = PublicKey::try_from_bytes(weak_key);
+            assert!(
+                result.is_err(),
+                "Small-order point #{} should be rejected but was accepted",
+                i
+            );
+            
+            // Verify the error message mentions weak keys
+            let err = result.unwrap_err();
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains("weak") || err_msg.contains("small-order"),
+                "Error message should mention weak/small-order keys, got: {}",
+                err_msg
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "rand")]
+    fn valid_public_keys_are_accepted() {
+        // Ensure that normal valid public keys are still accepted
+        for _ in 0..10 {
+            let kp = Keypair::generate();
+            let pk_bytes = kp.public().to_bytes();
+            let result = PublicKey::try_from_bytes(&pk_bytes);
+            assert!(result.is_ok(), "Valid public key should be accepted");
+        }
     }
 }

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -253,6 +253,13 @@ impl DerDecodable<'_> for Asn1RsaEncryption {
 /// i.e. encoded as a DER BIT STRING.
 struct Asn1SubjectPublicKey(PublicKey);
 
+/// Maximum allowed size for an RSA public key in PKCS#1 DER format.
+/// This library supports RSA keys from 2048 to 8192 bits (via ring's RSA_PKCS1_2048_8192_SHA256).
+/// An 8192-bit RSA modulus is 1024 bytes, plus the public exponent and DER overhead.
+/// We set a generous limit of 1200 bytes to accommodate the largest supported keys
+/// while preventing denial-of-service through oversized allocations.
+const MAX_RSA_PKCS1_DER_SIZE: usize = 1200;
+
 impl DerEncodable for Asn1SubjectPublicKey {
     fn encode<S: Sink>(&self, sink: &mut S) -> Result<(), Asn1DerError> {
         let pk_der = &(self.0).0;
@@ -274,9 +281,84 @@ impl DerDecodable<'_> for Asn1SubjectPublicKey {
             )));
         }
 
-        let pk_der: Vec<u8> = object.value().iter().skip(1).cloned().collect();
-        // We don't parse pk_der further as an ASN.1 RsaPublicKey, since
-        // we only need the DER encoding for `verify`.
+        let value = object.value();
+
+        // The BIT STRING must have at least one byte (the "unused bits" byte)
+        // plus the actual key data
+        if value.is_empty() {
+            return Err(Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key BIT STRING is empty.",
+            )));
+        }
+
+        // Check the "unused bits" byte - for RSA keys this should be 0
+        // (key length is always a multiple of 8 bits)
+        if value[0] != 0 {
+            return Err(Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key BIT STRING has non-zero unused bits.",
+            )));
+        }
+
+        // Check size bounds BEFORE allocating to prevent DoS via oversized inputs.
+        // The key data is everything after the "unused bits" byte.
+        let key_data_len = value.len() - 1;
+        if key_data_len > MAX_RSA_PKCS1_DER_SIZE {
+            return Err(Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key exceeds maximum allowed size.",
+            )));
+        }
+
+        // Validate that the inner data is a valid DER SEQUENCE (PKCS#1 RSAPublicKey structure)
+        // before allocating. The first byte should be 0x30 (SEQUENCE tag).
+        let key_data = &value[1..];
+        if key_data.is_empty() || key_data[0] != 0x30 {
+            return Err(Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key is not a valid PKCS#1 RSAPublicKey SEQUENCE.",
+            )));
+        }
+
+        // Parse as a DER object to validate the structure before allocating a Vec
+        let inner_obj = DerObject::decode(key_data).map_err(|_| {
+            Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key contains invalid DER encoding.",
+            ))
+        })?;
+
+        // Verify it's a SEQUENCE with the expected structure (n INTEGER, e INTEGER)
+        let seq = Sequence::load(inner_obj).map_err(|_| {
+            Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key is not a valid SEQUENCE.",
+            ))
+        })?;
+
+        // PKCS#1 RSAPublicKey has exactly 2 elements: modulus (n) and exponent (e)
+        if seq.len() != 2 {
+            return Err(Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key SEQUENCE does not have exactly 2 elements.",
+            )));
+        }
+
+        // Verify both elements are INTEGERs (tag 0x02)
+        let n_obj = seq.get(0).map_err(|_| {
+            Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "Failed to get RSA modulus from SEQUENCE.",
+            ))
+        })?;
+        let e_obj = seq.get(1).map_err(|_| {
+            Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "Failed to get RSA exponent from SEQUENCE.",
+            ))
+        })?;
+
+        if n_obj.tag() != 2 || e_obj.tag() != 2 {
+            return Err(Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
+                "RSA public key components are not INTEGERs.",
+            )));
+        }
+
+        // Now that we've validated the structure, allocate the Vec
+        let pk_der: Vec<u8> = key_data.to_vec();
+
         Ok(Self(PublicKey(pk_der)))
     }
 }
@@ -358,5 +440,99 @@ mod tests {
         QuickCheck::new()
             .tests(10)
             .quickcheck(prop as fn(_, _) -> _);
+    }
+
+    #[test]
+    fn rsa_reject_oversized_public_key() {
+        // Construct a malicious X.509 SubjectPublicKeyInfo with an oversized BIT STRING
+        // This should be rejected before any large allocation occurs
+
+        // RSA algorithm identifier: SEQUENCE { OID rsaEncryption, NULL }
+        let alg_id: &[u8] = &[
+            0x30, 0x0d, // SEQUENCE, length 13
+            0x06, 0x09, // OID, length 9
+            0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, // rsaEncryption OID
+            0x05, 0x00, // NULL
+        ];
+
+        // Create a BIT STRING claiming to contain a huge key (but with minimal actual data)
+        // BIT STRING tag = 0x03, then length encoding for > MAX_RSA_PKCS1_DER_SIZE
+        // We'll use a length that exceeds the limit
+        let oversized_len = MAX_RSA_PKCS1_DER_SIZE + 100;
+
+        // Construct the BIT STRING with long-form length encoding
+        let mut bit_string = vec![0x03]; // BIT STRING tag
+        // Long-form length: 0x82 means 2 bytes follow for length
+        bit_string.push(0x82);
+        bit_string.push(((oversized_len >> 8) & 0xff) as u8);
+        bit_string.push((oversized_len & 0xff) as u8);
+        bit_string.push(0x00); // unused bits byte
+        // Add minimal fake data (not a valid RSA key, but we should reject on size first)
+        bit_string.extend(vec![0x30; oversized_len - 1]); // Pad with SEQUENCE tags
+
+        // Build the full SPKI structure
+        let mut spki = vec![0x30]; // SEQUENCE tag
+        let inner_len = alg_id.len() + bit_string.len();
+        // Long-form length for outer SEQUENCE
+        spki.push(0x82);
+        spki.push(((inner_len >> 8) & 0xff) as u8);
+        spki.push((inner_len & 0xff) as u8);
+        spki.extend_from_slice(alg_id);
+        spki.extend_from_slice(&bit_string);
+
+        let result = PublicKey::try_decode_x509(&spki);
+        assert!(result.is_err(), "Oversized RSA public key should be rejected");
+    }
+
+    #[test]
+    fn rsa_reject_invalid_inner_structure() {
+        // Construct an X.509 SPKI with a BIT STRING that doesn't contain a valid PKCS#1 structure
+
+        // RSA algorithm identifier
+        let alg_id: &[u8] = &[
+            0x30, 0x0d,
+            0x06, 0x09,
+            0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01,
+            0x05, 0x00,
+        ];
+
+        // BIT STRING containing garbage instead of a valid RSA key
+        let invalid_key: &[u8] = &[
+            0x03, 0x05, // BIT STRING, length 5
+            0x00,       // unused bits = 0
+            0x01, 0x02, 0x03, 0x04, // garbage data (not starting with 0x30 SEQUENCE)
+        ];
+
+        let mut spki = vec![0x30]; // SEQUENCE tag
+        let inner_len = alg_id.len() + invalid_key.len();
+        spki.push(inner_len as u8);
+        spki.extend_from_slice(alg_id);
+        spki.extend_from_slice(invalid_key);
+
+        let result = PublicKey::try_decode_x509(&spki);
+        assert!(result.is_err(), "Invalid inner structure should be rejected");
+    }
+
+    #[test]
+    fn rsa_reject_empty_bit_string() {
+        // RSA algorithm identifier
+        let alg_id: &[u8] = &[
+            0x30, 0x0d,
+            0x06, 0x09,
+            0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01,
+            0x05, 0x00,
+        ];
+
+        // Empty BIT STRING
+        let empty_key: &[u8] = &[0x03, 0x00]; // BIT STRING, length 0
+
+        let mut spki = vec![0x30];
+        let inner_len = alg_id.len() + empty_key.len();
+        spki.push(inner_len as u8);
+        spki.extend_from_slice(alg_id);
+        spki.extend_from_slice(empty_key);
+
+        let result = PublicKey::try_decode_x509(&spki);
+        assert!(result.is_err(), "Empty BIT STRING should be rejected");
     }
 }

--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -112,13 +112,35 @@ impl SecretKey {
     ///
     /// [RFC5915]: https://tools.ietf.org/html/rfc5915
     pub fn from_der(mut der: impl AsMut<[u8]>) -> Result<SecretKey, DecodingError> {
-        // TODO: Stricter parsing.
         let der_obj = der.as_mut();
 
-        let mut sk_bytes = Sequence::decode(der_obj)
-            .and_then(|seq| seq.get(1))
-            .and_then(Vec::load)
-            .map_err(|e| DecodingError::failed_to_parse("secp256k1 SecretKey bytes", e))?;
+        let seq = Sequence::decode(der_obj)
+            .map_err(|e| DecodingError::failed_to_parse("secp256k1 ECPrivateKey SEQUENCE", e))?;
+
+        // Get the private key octet string (element at index 1 in ECPrivateKey)
+        let pk_obj = seq
+            .get(1)
+            .map_err(|e| DecodingError::failed_to_parse("secp256k1 privateKey field", e))?;
+
+        // Verify it's an OCTET STRING (tag 0x04)
+        if pk_obj.tag() != 4 {
+            return Err(DecodingError::new(
+                "secp256k1 privateKey is not an OCTET STRING".to_string(),
+            ));
+        }
+
+        // Check the size BEFORE allocating - secp256k1 secret keys are exactly 32 bytes
+        let pk_value = pk_obj.value();
+        if pk_value.len() != 32 {
+            return Err(DecodingError::new(format!(
+                "secp256k1 privateKey has invalid length: expected 32 bytes, got {}",
+                pk_value.len()
+            )));
+        }
+
+        // Now we can safely copy into a fixed-size array (no heap allocation for key material)
+        let mut sk_bytes = [0u8; 32];
+        sk_bytes.copy_from_slice(pk_value);
 
         let sk = SecretKey::try_from_bytes(&mut sk_bytes)?;
         sk_bytes.zeroize();
@@ -236,5 +258,138 @@ mod tests {
         let sk2 = SecretKey::try_from_bytes(&mut sk_bytes).unwrap();
         assert_eq!(sk1.0.serialize(), sk2.0.serialize());
         assert_eq!(sk_bytes, [0; 32]);
+    }
+
+    #[test]
+    fn secp256k1_reject_oversized_der_private_key() {
+        // Construct a malicious ECPrivateKey DER structure with an oversized private key field
+        // ECPrivateKey ::= SEQUENCE {
+        //   version        INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
+        //   privateKey     OCTET STRING,  <- This should be exactly 32 bytes
+        //   parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
+        //   publicKey  [1] BIT STRING OPTIONAL
+        // }
+
+        // Build an ECPrivateKey with a 64-byte (oversized) private key
+        let oversized_key = vec![0xAB; 64]; // 64 bytes instead of 32
+
+        let mut der = Vec::new();
+        // SEQUENCE tag
+        der.push(0x30);
+
+        // Calculate inner length
+        let version_len = 3; // INTEGER 1
+        let pk_len = 2 + oversized_key.len(); // OCTET STRING header + data
+        let inner_len = version_len + pk_len;
+
+        // Length (short form since < 128)
+        der.push(inner_len as u8);
+
+        // version INTEGER = 1
+        der.push(0x02); // INTEGER tag
+        der.push(0x01); // length 1
+        der.push(0x01); // value 1
+
+        // privateKey OCTET STRING (oversized)
+        der.push(0x04); // OCTET STRING tag
+        der.push(oversized_key.len() as u8); // length
+        der.extend_from_slice(&oversized_key);
+
+        let result = SecretKey::from_der(&mut der);
+        assert!(result.is_err(), "Oversized secp256k1 private key should be rejected");
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("invalid length") || err_msg.contains("32"),
+            "Error should mention invalid length, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn secp256k1_reject_undersized_der_private_key() {
+        // Build an ECPrivateKey with a 16-byte (undersized) private key
+        let undersized_key = vec![0xAB; 16]; // 16 bytes instead of 32
+
+        let mut der = Vec::new();
+        der.push(0x30); // SEQUENCE
+
+        let version_len = 3;
+        let pk_len = 2 + undersized_key.len();
+        let inner_len = version_len + pk_len;
+        der.push(inner_len as u8);
+
+        // version
+        der.push(0x02);
+        der.push(0x01);
+        der.push(0x01);
+
+        // privateKey OCTET STRING (undersized)
+        der.push(0x04);
+        der.push(undersized_key.len() as u8);
+        der.extend_from_slice(&undersized_key);
+
+        let result = SecretKey::from_der(&mut der);
+        assert!(result.is_err(), "Undersized secp256k1 private key should be rejected");
+    }
+
+    #[test]
+    fn secp256k1_reject_non_octet_string_private_key() {
+        // Build an ECPrivateKey where the private key field is not an OCTET STRING
+        let fake_key = vec![0xAB; 32];
+
+        let mut der = Vec::new();
+        der.push(0x30); // SEQUENCE
+
+        let version_len = 3;
+        let pk_len = 2 + fake_key.len();
+        let inner_len = version_len + pk_len;
+        der.push(inner_len as u8);
+
+        // version
+        der.push(0x02);
+        der.push(0x01);
+        der.push(0x01);
+
+        // Use INTEGER tag (0x02) instead of OCTET STRING (0x04)
+        der.push(0x02); // Wrong tag!
+        der.push(fake_key.len() as u8);
+        der.extend_from_slice(&fake_key);
+
+        let result = SecretKey::from_der(&mut der);
+        assert!(result.is_err(), "Non-OCTET-STRING private key should be rejected");
+    }
+
+    #[test]
+    #[cfg(feature = "rand")]
+    fn secp256k1_valid_der_roundtrip() {
+        // Generate a valid key and verify we can create a proper DER encoding that works
+        let sk = SecretKey::generate();
+        let sk_bytes = sk.to_bytes();
+
+        // Build a minimal valid ECPrivateKey DER
+        let mut der = Vec::new();
+        der.push(0x30); // SEQUENCE
+
+        let version_len = 3;
+        let pk_len = 2 + 32; // OCTET STRING header + 32-byte key
+        let inner_len = version_len + pk_len;
+        der.push(inner_len as u8);
+
+        // version INTEGER = 1
+        der.push(0x02);
+        der.push(0x01);
+        der.push(0x01);
+
+        // privateKey OCTET STRING
+        der.push(0x04);
+        der.push(32);
+        der.extend_from_slice(&sk_bytes);
+
+        let result = SecretKey::from_der(&mut der);
+        assert!(result.is_ok(), "Valid DER-encoded key should be accepted");
+
+        let decoded_sk = result.unwrap();
+        assert_eq!(decoded_sk.to_bytes(), sk_bytes, "Decoded key should match original");
     }
 }


### PR DESCRIPTION
this is really just for completeness, the vulnerabilities are in upstream libp2p-identity and only apply to the classical crypto paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes signature verification and key-import behavior for Ed25519, RSA, and secp256k1; valid peers using weak keys or loose DER may start failing, but the changes are defensive against forgery and DoS via oversized inputs.
> 
> **Overview**
> Hardens **classical** identity crypto paths (aligned with upstream **libp2p-identity** fixes): stricter parsing and verification on untrusted key/signature inputs.
> 
> **Ed25519:** `PublicKey::verify` now uses **`verify_strict`** (rejects malleable signatures and related edge cases). **`try_from_bytes`** rejects **small-order / weak** public keys via `is_weak()`, with tests for all eight torsion points.
> 
> **RSA (X.509 SPKI):** Decoding no longer blindly copies the BIT STRING. It enforces empty/non-zero unused-bits rules, a **`MAX_RSA_PKCS1_DER_SIZE`** cap **before** allocation, and PKCS#1 **RSAPublicKey** shape (SEQUENCE of two INTEGERs). Tests cover oversized, empty, and malformed inner encodings.
> 
> **Secp256k1:** `SecretKey::from_der` requires the private key field to be an **OCTET STRING** of **exactly 32 bytes**, copied into a stack buffer instead of allocating from attacker-controlled lengths. Tests cover wrong length, wrong tag, and valid roundtrip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482220573f84a663a947eeccbb0d635601dda4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->